### PR TITLE
fix(增加权限): 在 清单文件中新增 权限： <uses-permission android:name="android.permi…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <!-- 3.2.0版本增加-->
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
通知栏无法弹出，是因为缺少了 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" /> 这个权限，
加上去了
